### PR TITLE
chore: release v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/eRgo35/lyra/compare/v0.10.3...v0.10.4) - 2024-08-13
+
+### Fixed
+- added wip info for some commands
+
+### Other
+- cargo-dist action setup
+- repo added to Cargo.toml
+- using cargo-dist for package building
+
 ## [0.10.3](https://github.com/eRgo35/lyra/compare/v0.10.2...v0.10.3) - 2024-08-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "lyra"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dotenv",
  "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyra"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Michał Czyż <mike@c2yz.com>"]
 edition = "2021"
 description = "A featureful Discord bot written in Rust."


### PR DESCRIPTION
## 🤖 New release
* `lyra`: 0.10.3 -> 0.10.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.4](https://github.com/eRgo35/lyra/compare/v0.10.3...v0.10.4) - 2024-08-13

### Fixed
- added wip info for some commands

### Other
- cargo-dist action setup
- repo added to Cargo.toml
- using cargo-dist for package building
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).